### PR TITLE
SVNUrl, support for '#' in filename

### DIFF
--- a/base/src/main/java/org/tigris/subversion/svnclientadapter/SVNUrl.java
+++ b/base/src/main/java/org/tigris/subversion/svnclientadapter/SVNUrl.java
@@ -302,7 +302,7 @@ public class SVNUrl {
     	// to handle other classes OK.  I tested with @ + and Unicode characters.  It leaves
     	// the @ and + alone and converts Unicode to %nn.  It is possible there are other
     	// characters we need to replace here besides space.
-    	String s = get().replace(" ", "%20").replace("[", "%5B").replace("]","%5D");
+    	String s = get().replace(" ", "%20").replace("[", "%5B").replace("]","%5D").replace("#","%23");
 		try {
 			URI u = new URI(s);
 			return u.toASCIIString();


### PR DESCRIPTION
In SVN-Repository perspective, when user wants to open a file containing '#' in filename, editor fails with message "Failed in RemoteFile.getContents()" and "Bogus Url" error is written in console.